### PR TITLE
Added scrollability to Rooms and filtering for custom name boost/bridges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ bower_components
 package.zip
 *.map
 js/*
+.idea
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonos-controller-unofficial",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Unoffical sonos controller for linux",
   "main": "app/main.js",
   "scripts": {

--- a/src/ui/components/Application.jsx
+++ b/src/ui/components/Application.jsx
@@ -39,7 +39,13 @@ class Application extends Component {
 					<div id="column-container">
 						<div id="zone-container">
 							<h4>ROOMS</h4>
-							<ZoneGroupList />
+
+							<div id="zone-container" style="width:100%;display: flex; flex-direction: column;">
+								<div style="overflow-y: auto;">
+									<ZoneGroupList />
+								</div>
+							</div>
+
 						</div>
 
 						<div id="status-container">

--- a/src/ui/services/SonosService.js
+++ b/src/ui/services/SonosService.js
@@ -96,7 +96,6 @@ let SonosService = {
 		let currentGroupMatch;
 
 		sonos.getTopology((err, info) => {
-
 			if(err) {
 				return;
 			}
@@ -109,13 +108,14 @@ let SonosService = {
 			}
 
 			if(!currentGroupMatch || !currentZone) {
-
-				let zone = _(info.zones).reject({ name: "BRIDGE" }).reject({ name: "BOOST" }).find({
+				let zone = _(info.zones).reject(function(z) { return(z.name.toLocaleLowerCase().match("bridge")) })
+					.reject(function(z) { return(z.name.toLocaleLowerCase().match("boost")) }).find({
 					coordinator: "true"
 				});
 
 				if(window.localStorage.zone) {
-					let match = _(info.zones).reject({ name: "BRIDGE" }).reject({ name: "BOOST" }).find({
+					let match = _(info.zones).reject(function(z) { return(z.name.toLocaleLowerCase().match("bridge")) })
+						.reject(function(z) { return(z.name.toLocaleLowerCase().match("boost")) }).find({
 						uuid: window.localStorage.zone,
 						coordinator: "true"
 					});

--- a/src/ui/stores/ZoneGroupStore.js
+++ b/src/ui/stores/ZoneGroupStore.js
@@ -21,8 +21,8 @@ var ZoneGroupStore = _.assign({}, events.EventEmitter.prototype, {
 	},
 
 	setAll (groups) {
-		this._groups = _(groups).reject({ name: "BRIDGE" })
-								.reject({ name: "BOOST" })
+		this._groups = _(groups).reject(function(z) { return(z.name.toLocaleLowerCase().match("bridge")) })
+								.reject(function(z) { return(z.name.toLocaleLowerCase().match("boost")) })
 								.sortBy('name')
 								.groupBy('group')
 								.value();


### PR DESCRIPTION
This is a picture of the problem -
There is no way to scroll to other rooms
Bridges with custom names are not filtered out of the list.

![sonos](https://cloud.githubusercontent.com/assets/6561/22858331/ba55782e-f07f-11e6-986f-0d3e9a16ba0d.png)

I have a lot of sonos equipment and a number of bridges.  I added in some css to make it scroll when the list is longer than can be displayed.
I added in a function to look for the name bridge/boost even if they add something to the name.