### PR TITLE
Correct VirtualList rowHeight

### DIFF
--- a/src/ui/components/QueueList.jsx
+++ b/src/ui/components/QueueList.jsx
@@ -170,7 +170,7 @@ export class QueueList extends Component {
                         onDragEnd={this._onDragEnd.bind(this)}
                     >
                         <VirtualList
-                            rowHeight={50}
+                            rowHeight={53}
                             sync={true}
                             class="scrollcontainer"
                             data={queueItemNodes || []}

--- a/src/ui/components/__tests__/__snapshots__/QueueList.test.js.snap
+++ b/src/ui/components/__tests__/__snapshots__/QueueList.test.js.snap
@@ -24,7 +24,7 @@ exports[`QueueList renders and matches snapshot 1`] = `
         onScroll={[Function anonymous]}
         class="scrollcontainer"
       >
-        <div style="position:relative; overflow:hidden; width:100%; min-height:100%; height:50px;">
+        <div style="position:relative; overflow:hidden; width:100%; min-height:100%; height:53px;">
           <div style="position:absolute; top:0; left:0; height:100%; width:100%; overflow:visible; top:0px;"></div>
         </div>
       </div>


### PR DESCRIPTION
Within the QueueList component, `VirtualList[rowHeight]` was set to 50.

However, the rendered height of the rows is actually 53px (51px height plus 1px of padding above and below).

This causes the last item in the queue to not be fully rendered.  This becomes increasingly apparent the more items in the queue there are, eventually resulting in items becoming unreachable entirely (this is issue #49).

Increasing the `[rowHeight]` property to match the actually rendered height completely resolves this issue.

Tested locally on my Linux Mint machine.