### PR TITLE
Added manual IP input possibility if discovery fails

### DIFF
--- a/src/ui/services/SonosService.js
+++ b/src/ui/services/SonosService.js
@@ -6,6 +6,8 @@ import { initialise as initialiseServiceLogos } from '../helpers/getServiceLogoU
 
 import { discoverMultiple } from './enhanced/Discovery';
 
+import { connectStatic } from './enhanced/ConnectStatic';
+
 import * as serviceActions from '../reduxActions/SonosServiceActions';
 
 import {
@@ -77,12 +79,17 @@ const SonosService = {
         return getSonosDeviceOrCurrentOrFirst();
     },
 
-    async searchForDevices(timeout = 1000) {
-        const devices = await discoverMultiple({
-            timeout,
-            port: SONOS_DISCOVERY_PORT,
-        });
-
+    async searchForDevices(timeout = 1000, staticIp = '') {
+        let devices = [];
+        if (staticIp) {
+            const sonos = await connectStatic(staticIp);
+            devices.push(sonos);
+        } else {
+            devices = await discoverMultiple({
+                timeout,
+                port: SONOS_DISCOVERY_PORT,
+            });
+        }
         const [first] = devices;
         const groups = await first.getAllGroups();
 

--- a/src/ui/services/SonosService.js
+++ b/src/ui/services/SonosService.js
@@ -79,11 +79,11 @@ const SonosService = {
         return getSonosDeviceOrCurrentOrFirst();
     },
 
-    async searchForDevices(timeout = 1000, staticIp = '') {
+    async searchForDevices(timeout = 1000, staticIps = []) {
         let devices = [];
-        if (staticIp) {
-            const sonos = await connectStatic(staticIp);
-            devices.push(sonos);
+        if (staticIps.length > 0) {
+            let players = await connectStatic(staticIps);
+            devices = devices.concat(players);
         } else {
             devices = await discoverMultiple({
                 timeout,

--- a/src/ui/services/enhanced/ConnectStatic.js
+++ b/src/ui/services/enhanced/ConnectStatic.js
@@ -1,10 +1,12 @@
-import SonosEnhanced from "./SonosEnhanced";
+import SonosEnhanced from './SonosEnhanced';
 
-export async function connectStatic(host, port = 1400) {
-    if(host) {
+export async function connectStatic(hosts, port = 1400) {
+    const players = [];
+    for (const host of hosts) {
         //model is not really used anywhere, let's ignore it for now
         let sonosEnhanced = new SonosEnhanced(host, null);
         await sonosEnhanced.initialise();
-        return sonosEnhanced;
+        players.push(sonosEnhanced);
     }
+    return players;
 }

--- a/src/ui/services/enhanced/ConnectStatic.js
+++ b/src/ui/services/enhanced/ConnectStatic.js
@@ -1,0 +1,10 @@
+import SonosEnhanced from "./SonosEnhanced";
+
+export async function connectStatic(host, port = 1400) {
+    if(host) {
+        //model is not really used anywhere, let's ignore it for now
+        let sonosEnhanced = new SonosEnhanced(host, null);
+        await sonosEnhanced.initialise();
+        return sonosEnhanced;
+    }
+}


### PR DESCRIPTION
I extended the function that initiates the device search to be able to connect to a manually given IP address. The solution is initial and botched but it works.
I use it when connected to a VPN and discovery fails searching my local network.
Right now, it works by calling
```self.SonosService.searchForDevices(1000,'192.168.0.12')```
from the console, replacing the IP address with your own.