### PR TITLE
encode id because sonos doesn't seem to like some special characters in the id

### DIFF
--- a/src/localMusic/server.js
+++ b/src/localMusic/server.js
@@ -87,6 +87,7 @@ class SmapiServer {
     }
 
     async getMediaURI({ id }) {
+        id = decodeURIComponent(id);
         const pathEncoded = encodeURIComponent(id);
         const isFile = await isAllowedFile(path.resolve(ROOT, id));
 
@@ -249,7 +250,7 @@ class SmapiServer {
         if (id === 'root') {
             target = ROOT;
         } else {
-            const p = path.resolve(ROOT, id);
+            const p = decodeURIComponent(path.resolve(ROOT, id));
             const isDir = await isAllowedDirectory(p);
 
             if (!isDir) {
@@ -277,7 +278,7 @@ class SmapiServer {
             try {
                 const isDir = await isAllowedDirectory(p);
                 const isFile = await isAllowedFile(p);
-                const pathID = path.relative(ROOT, p);
+                const pathID = encodeURIComponent(path.relative(ROOT, p));
                 const pathEncoded = encodeURIComponent(pathID);
                 if (isDir) {
                     const title = path.basename(p);


### PR DESCRIPTION
This PR allows for viewing a listing of On this device localMusic even when the files in the local music folder contain special characters that sonos doesn't seem to appreciate.  Furthermore, it is able to play these files that contain special characters in the filename.

According to the Sonos documentation for [getMetadata](https://developer.sonos.com/reference/sonos-music-api/getmetadata/#Requestnbspparameters), the id is simply a type `string(128)`, but for whatever reason, at least `&` is not an acceptable character in the id for Sonos.  By eliminating the special characters using encodeURIComponent, Sonos is able to list and play the localMusic.

Resolves #172 